### PR TITLE
Fix "KeyError" exception on "System Album" and "Page" node types

### DIFF
--- a/smugmugv2py/Node.py
+++ b/smugmugv2py/Node.py
@@ -10,15 +10,17 @@ class Node(object):
 		self.type = node["Type"]
 		self.privacy = node["Privacy"]
 		self.has_children = node["HasChildren"]
-		self.sort_method = node["SortMethod"]
-		self.sort_direction = node["SortDirection"]
 
-		if self.type == "Album":
+		if self.type == "Album" or self.type == "System Album":
+			self.sort_method = node["SortMethod"]
+			self.sort_direction = node["SortDirection"]
 			if "Uri" in node["Uris"]["Album"]:
 				self.album = node["Uris"]["Album"]["Uri"]
 			else:
 				self.album = node["Uris"]["Album"]
-		else:
+		elif self.type == "Folder":
+			self.sort_method = node["SortMethod"]
+			self.sort_direction = node["SortDirection"]
 			if "Uri" in node["Uris"]["ChildNodes"]:
 				self.__child_nodes = node["Uris"]["ChildNodes"]["Uri"]
 			else:


### PR DESCRIPTION
Prior to this change, the Node class would throw a KeyError exception when
instantiating a "System Album" or "Page" node.  This change adds support for
the "System Album" node type (handling it the same as a regular album), and
checks the node type prior to extracting type-specific values so that unknown
types are handled gracefully.

Note there is no explicit support for the "Page" node type; this is reasonable
as the v2.0 API does not expose any actionable values for Page nodes.