### PR TITLE
Fix TypeError exception when printing Album contents

### DIFF
--- a/test.py
+++ b/test.py
@@ -14,7 +14,7 @@ def do_indent(indent):
 		stdout.write(" ")
 
 def print_album(node, indent):
-	album = Album(Album.get_album(connection, node.album))
+	album = Album.get_album(connection, node.album)
 	stdout.write(", " + str(album.image_count) + " images")
 	images = album.get_images(connection)
 	for image in images:


### PR DESCRIPTION
The print_album() function tries to instantiate an Album object twice, passing an object in where a dictionary is expected and throwing a `TypeError: 'Album' object has no attribute '__getitem__'` exception.

Committing this micro-fix by itself because test.py is typically used as an example for new code.