### PR TITLE
Rename "album" member variable in class Node to prevent collisions

### DIFF
--- a/smugmugv2py/Node.py
+++ b/smugmugv2py/Node.py
@@ -15,9 +15,9 @@ class Node(object):
 			self.sort_method = node["SortMethod"]
 			self.sort_direction = node["SortDirection"]
 			if "Uri" in node["Uris"]["Album"]:
-				self.album = node["Uris"]["Album"]["Uri"]
+				self.album_uri = node["Uris"]["Album"]["Uri"]
 			else:
-				self.album = node["Uris"]["Album"]
+				self.album_uri = node["Uris"]["Album"]
 		elif self.type == "Folder":
 			self.sort_method = node["SortMethod"]
 			self.sort_direction = node["SortDirection"]

--- a/test.py
+++ b/test.py
@@ -14,7 +14,7 @@ def do_indent(indent):
 		stdout.write(" ")
 
 def print_album(node, indent):
-	album = Album.get_album(connection, node.album)
+	album = Album.get_album(connection, node.album_uri)
 	stdout.write(", " + str(album.image_count) + " images")
 	images = album.get_images(connection)
 	for image in images:
@@ -75,8 +75,8 @@ try:
 		# creating the child folder privately so people can run this test script 'safely'.
 		new_node=node.create_child_album(connection, 'testalbum','Testalbum','Private', 'A long description for the album')
 
-	print new_node.uri + " - " + new_node.name + new_node.album
-	album=Album.get_album(connection, new_node.album)
+	print new_node.uri + " - " + new_node.name + new_node.album_uri
+	album=Album.get_album(connection, new_node.album_uri)
 
 	try:
 		pprint(connection.upload_image('adhawkins_github_avatar.jpg',


### PR DESCRIPTION
THIS IS AN INCOMPATIBLE INTERFACE CHANGE

The original code overloads the variable name "album" in three ways:

- An instantiated object (class Album);
- A string (URI), as a member variable in class Node;
- A dictionary (decoded JSON response), in the class initializer.

For example, from test.py:

`album = Album.get_album(connection, node.album)
`

Here, the first use of `album` is an object, but the last is a string.  While the possibility of confusion (and coding errors) is real, this also will make it harder in the future if we want to add methods that might return either an Album object or an album URI.

This change renames the `Node` member variable to `album_uri`, consistent with variable naming elsewhere in the library.

This change does not change the use of the "album" name for a dictionary. It might also be wise in the future to implement accessor methods.