### PR TITLE
typecast long to string for header, Content-Length

### DIFF
--- a/smugmugv2py/Connection.py
+++ b/smugmugv2py/Connection.py
@@ -160,7 +160,7 @@ class Connection(object):
 			'Content-Type': guess_type(filename)[0],
 			'X-Smug-AlbumUri': album_uri,
 			'X-Smug-FileName': filename,
-			'Content-Length': path.getsize(filename),
+			'Content-Length': str(path.getsize(filename)),
 		}
 
 		if caption is not None:


### PR DESCRIPTION
Never versions of requests does not support none string header types.